### PR TITLE
Legger inn allowReserved=false

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -820,6 +820,7 @@ components:
       name: locking
       style: deepObject
       explode: true
+      allowReserved: false
       schema:
         type: object
         properties:


### PR DESCRIPTION
Fra spec (https://swagger.io/docs/specification/serialization/#query):

Additionally, the allowReserved keyword specifies whether the reserved characters :/?#[]@!$&'()*+,;= in parameter values are allowed to be sent as they are, or should be percent-encoded. By default, allowReserved is false, and reserved characters are percent-encoded. For example, / is encoded as %2F (or %2f), so that the parameter value quotes/h2g2.txt will be sent as quotes%2Fh2g2.txt