### PR TITLE
Fjerner format byte i cursor

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -703,7 +703,6 @@ components:
       name: cursor
       schema:
         type: string
-        format: byte
       description: Brukes til porsjonering av data
     bboxParam:
       in: query


### PR DESCRIPTION
Det blir for komplisert å benytte base64-enkodet byte-string. Velger derfor heller å bruke "ren" string, slik at det blir enklere å hente ut flere porsjoner.