### PR TITLE
Utvidelser / forbedringer i NGIS-OpenAPI for å øke kompatibilitet med dagens NGIS-API

### DIFF
--- a/spec/examples/changelog/Bbox.json
+++ b/spec/examples/changelog/Bbox.json
@@ -1,0 +1,478 @@
+[
+    {
+        "areaname": "",
+        "comment": "Antall porsjoner: 6",
+        "features": {
+            "bbox": [
+                576523.08,
+                6717360.100000001,
+                620817.4400000001,
+                6805857.2
+            ],
+            "created": "55769",
+            "erased": "0",
+            "replaced": "0"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "",
+        "timestamp": "2023-02-13T14:59:08",
+        "username": ""
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.9.9.0)\n\nAntall porsjoner: 7",
+        "features": {
+            "bbox": [
+                576523.08,
+                6717360.100000001,
+                620817.4400000001,
+                6805857.2
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "55769"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-02-14T12:54:05",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.3.0)\n\nAntall porsjoner: 7",
+        "features": {
+            "bbox": [
+                576523.08,
+                6717360.100000001,
+                620817.4400000001,
+                6805857.2
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "55769"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-07-20T10:00:25",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "2",
+            "erased": "0",
+            "replaced": "0"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-25T12:52:26",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "1",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T10:33:51",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "0",
+            "erased": "1",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T10:54:52",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "1",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T11:00:02",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "0",
+            "erased": "1",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T11:02:38",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601614.0791304412,
+                6797132.512170927,
+                601628.1410552382,
+                6797140.5221983595
+            ],
+            "created": "2",
+            "erased": "0",
+            "replaced": "0"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T11:24:25",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601614.0791304412,
+                6797132.512170927,
+                601628.1410552382,
+                6797140.5221983595
+            ],
+            "created": "1",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T11:30:59",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601614.0791304412,
+                6797132.512170927,
+                601650.8955703481,
+                6797162.765376051
+            ],
+            "created": "4",
+            "erased": "3",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T12:49:51",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.1128812457,
+                6797158.599073217
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:12:56",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.1128812457,
+                6797158.599073217
+            ],
+            "created": "2",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:23:10",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                601616.2524602651,
+                6797136.815002077,
+                601650.1128812457,
+                6797158.599073217
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:34:48",
+        "username": "zf"
+    }
+]

--- a/spec/examples/changelog/BboxTransformasjonNomralisering.json
+++ b/spec/examples/changelog/BboxTransformasjonNomralisering.json
@@ -1,0 +1,104 @@
+[
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.9.9.0)\n\nAntall porsjoner: 7",
+        "features": {
+            "bbox": [
+                10.396726321012716,
+                60.58485059468328,
+                11.260310308754049,
+                61.36788441323802
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "55769"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-02-14T12:54:05",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.3.0)\n\nAntall porsjoner: 7",
+        "features": {
+            "bbox": [
+                10.396726321012716,
+                60.58485059468328,
+                11.260310308754049,
+                61.36788441323802
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "55769"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-07-20T10:00:25",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.3.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                10.527477858869762,
+                61.05941912302402,
+                10.536959969381932,
+                61.063014709335384
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-07-21T11:11:04",
+        "username": "zf"
+    }
+]

--- a/spec/examples/changelog/Transformasjon.json
+++ b/spec/examples/changelog/Transformasjon.json
@@ -1,0 +1,342 @@
+[
+    {
+        "areaname": "",
+        "comment": "Antall porsjoner: 6",
+        "features": {
+            "bbox": [
+                60.58485059468328,
+                10.396726321012716,
+                61.36788441323802,
+                11.260310308754049
+            ],
+            "created": "55769",
+            "erased": "0",
+            "replaced": "0"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "",
+        "timestamp": "2023-02-13T14:59:08",
+        "username": ""
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.3.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.05941912302402,
+                10.527477858869762,
+                61.063014709335384,
+                10.536959969381932
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-07-21T11:25:46",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295358006900756,
+                10.897263258745554
+            ],
+            "created": "2",
+            "erased": "0",
+            "replaced": "0"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": true,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-25T12:52:26",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295358006900756,
+                10.897263258745554
+            ],
+            "created": "1",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T10:33:51",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295358006900756,
+                10.897263258745554
+            ],
+            "created": "0",
+            "erased": "1",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T10:54:52",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295096153384755,
+                10.896560153066735,
+                61.295358006900756,
+                10.897263258745554
+            ],
+            "created": "4",
+            "erased": "3",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T12:49:51",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295320828421964,
+                10.897246401821624
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:12:56",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295320828421964,
+                10.897246401821624
+            ],
+            "created": "2",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:23:10",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                61.295134194561676,
+                10.896603021671948,
+                61.295320828421964,
+                10.897246401821624
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "2"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T13:34:48",
+        "username": "zf"
+    },
+    {
+        "areaname": "",
+        "comment": "(GISLINE 9.0.4.0)\n\nAntall porsjoner: 1",
+        "features": {
+            "bbox": [
+                60.976451706359285,
+                10.645848487539352,
+                61.031441162888626,
+                10.790101431598302
+            ],
+            "created": "0",
+            "erased": "0",
+            "replaced": "1"
+        },
+        "operations": {
+            "ArchiveMetadata": false,
+            "DataWrittenWithHistory": true,
+            "DelArchive": false,
+            "DelHistory": false,
+            "DelHistoryBeforeTimestamp": false,
+            "DelHorizontalRefSys": false,
+            "DelSpatialData": false,
+            "DelTypeRegistry": false,
+            "DelVerticalRefSys": false,
+            "HistoryWasRemoved": false,
+            "LastTransactionId": false,
+            "Parameters": false,
+            "SinglePortionWithCommit": false,
+            "TypeRegistry": false
+        },
+        "taskname": "3411VANN_2019_pg",
+        "timestamp": "2023-10-26T15:49:05",
+        "username": "rw"
+    }
+]

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -301,6 +301,7 @@ paths:
         - $ref: '#/components/parameters/clientHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lockingParam'
+        - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/bboxParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
@@ -548,6 +549,7 @@ paths:
         - $ref: '#/components/parameters/clientHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lockingParam'
+        - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
         - in: query
@@ -738,6 +740,7 @@ paths:
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lokalIdParam'
         - $ref: '#/components/parameters/lockingParam'
+        - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/referencesParam'
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/crsEPSGParam'
@@ -851,6 +854,38 @@ paths:
         '503':
           description: Intern feil på serveren (tjenesten er utilgjengelig)
   /datasets/{datasetId}/locks:
+    post:
+      tags:
+       - locks
+      summary: Lås features i et dataset uten å hente ut data.
+      description: |
+        Lenke til uthenting av data ligger i response `Link`-header på samme måte som porsjonering.
+      operationId: postDatasetLocks
+      parameters:
+        - $ref: '#/components/parameters/clientHeaderParam'
+        - $ref: '#/components/parameters/datasetIdParam'
+        - $ref: '#/components/parameters/lockingParam'
+        - $ref: '#/components/parameters/bboxParam'
+        - $ref: '#/components/parameters/crsEPSGParam'
+        - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
+      responses:
+        '200':      # Response
+          description: OK
+          content:  # Response body
+            application/vnd.kartverket.ngis.locks+json:  # Media type
+             schema: 
+               $ref: '#/components/schemas/Locks'    # Reference to object definition
+            application/vnd.kartverket.ngis.all_locks+json:
+             schema: 
+               $ref: '#/components/schemas/Locks'
+        '401':
+          description: Gyldig autentisering av brukeren mangler eller er ugyldig
+        '403':
+          description: Ugyldig brukernavn og/eller passord
+        '404':
+          description: Fant ikke angitt dataset
+        '406':
+          description: Formatet klienten ønsker på data er ugyldig. Klienten har f.eks en ugyldig Accept-header og kan ikke motta data på et format som serveren kan levere
     get:
       tags:
        - locks
@@ -1148,10 +1183,19 @@ components:
 
         *id_lock*
 
-        Hver bruker kan lage flere låser per dataset. Låsing av objektene må håndteres med POST /datasets/:id/locks.
+        Hver bruker kan lage flere låser per dataset. Låsing av objektene må håndteres med POST /datasets/:id/locks eller ved å hente ut data med `id_lock`. For sistnevnte må låsenøkkel/id hentes med GET /datasets/:id/locks.
         
         Låsen vil fjernes neste gang brukeren skriver data til dataset'et med `id_lock` og angitt låsenøkkel med `locking_id`, eller dersom låsen slettes.
-        
+
+    lockingIdParam:
+      in: query
+      name: locking_id
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+      description: |
+        Brukes ved skriving av data med lås, dersom lås er hentet med `locking_type=id_lock`.      
     lokalIdParam:
       in: path
       name: lokalId

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -347,6 +347,7 @@ paths:
         - $ref: '#/components/parameters/lockingParam'
         - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/bboxParam'
+        - $ref: '#/components/parameters/polygonParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
         - $ref: '#/components/parameters/referencesParam'
@@ -872,6 +873,7 @@ paths:
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lockingParam'
         - $ref: '#/components/parameters/bboxParam'
+        - $ref: '#/components/parameters/polygonParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
         - $ref: '#/components/parameters/referencesParam'
@@ -909,6 +911,7 @@ paths:
         - $ref: '#/components/parameters/lockingParam'
         - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/bboxParam'
+        - $ref: '#/components/parameters/polygonParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
       responses:
@@ -1218,7 +1221,25 @@ components:
         
         Dette kan være aktuelt for å få ut alle objekter som ikke er direkte knyttet til et objekt, som f.eks mønelinje og takkant til en bygning.
         
-        Merk: Dersom `references` ikke er angitt blir det satt til `none` 
+        Merk: Kan ikke kombineres med `polygon`. Dersom `references` ikke er angitt blir det satt til `none` 
+    polygonParam:
+      in: query
+      name: polygon
+      schema:
+        type: string
+      examples:
+        smallbbox:
+          summary: Et eksempelpolygon
+          description: |
+            Med WKT: POLYGON ((6.218262 60.06484, 6.218262 61.721118, 11.315918 61.721118, 11.315918 60.06484, 6.218262 60.06484))
+            blir WKB: 0103000000010000000500000095D6DF1280DF18407FBC57AD4C084E4095D6DF1280DF1840494739984DDC4E407A6F0C01C0A12640494739984DDC4E407A6F0C01C0A126407FBC57AD4C084E4095D6DF1280DF18407FBC57AD4C084E40
+          value: 0103000000010000000500000095D6DF1280DF18407FBC57AD4C084E4095D6DF1280DF1840494739984DDC4E407A6F0C01C0A12640494739984DDC4E407A6F0C01C0A126407FBC57AD4C084E4095D6DF1280DF18407FBC57AD4C084E40
+      description: |
+        Henter ut objekter i et bestemt område (angitt med et polygon)
+        
+        Dette kan være aktuelt for å få ut alle objekter som ikke er direkte knyttet til et objekt, som f.eks mønelinje og takkant til en bygning.
+        
+        Merk: Kan ikke kombineres med `bbox`. Dersom `references` ikke er angitt blir det satt til `none` 
     crsEPSGParam:
       in: query
       name: crs_EPSG

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -14,9 +14,10 @@ info:
       - Hente data fra et bestemt datasett
         - Med lesetilgang eller skrivetilgang (medfører låsing)
           - områdebegrensning
-          - egenskapsspørring (begrenset i første versjon til bygningsnummer eller lokalid)
+          - egenskapsspørring
       - Lagre data til et bestemt datasett
         - Operasjoner som håndteres: nytt objekt, endre objekt og slett objekt
+      - Metoder for å jobbe mot egenskapene til et objekt i et bestemt datasett
     
     ## Generelle prinsipper for systemet
     
@@ -59,8 +60,10 @@ info:
     ### Låsing
     
     Dette er nærmere beskrevet i de aktuelle kallene.
-
-    Foreløpig er det kun `user_lock` som er støttet. Det betyr at data må hentes ut med `user_lock` før de kan sendes inn med endringer.
+    
+    Det er to typer låser:
+    - `user_lock`, der man kun angir `locking_type=user_lock` ved henting og skriving av objekter. Hvis ikke samtlige objekter kan låses, feiler kallet. En bruker kan kun ha én lås per dataset av gangen.
+    - `id_lock`, der man angir `locking_type=id_lock` og må håndtere løsenøkkel `lock_id` selv. Hvis ikke samtlige objekter kan låses, blir kun de objektene som kan låses, låst. Resten forblir låst av andre. En bruker kan ha vilkårlig antall låser, men må holde styr på låsenøklene selv.
     
     ### Porsjonering
     
@@ -68,7 +71,9 @@ info:
     
     ### Koordinatsystemer og transformasjon
     
-    Dersom annet koordinatsystem enn det som ligger i dataset skal brukes (se `GET /datasets/{datasetId}`) må koordinatsystem angis med `crs_EPSG`-parameteret. Dette styrer data som sendes inn, data som hentes ut og koordinatsystemet i `bbox`-parameteret i kallet. For å bytte rekkefølge på aksene brukes `crs_normalized_for_visualization`-parameteret.
+    Dersom annet koordinatsystem enn det som ligger i dataset skal brukes (se `GET /datasets/{datasetId}`) må koordinatsystem angis med `crs_EPSG`-parameteret. 
+    Dette styrer data som sendes inn, data som hentes ut og koordinatsystemet i `bbox`-parameteret i kallet. 
+    For å bytte rekkefølge på aksene (gjelder kun for geodetiske koordinater lat/lon) brukes `crs_normalized_for_visualization`-parameteret.
     
     ### Historikk og historiske endringer
     
@@ -1131,16 +1136,22 @@ components:
       name: locking_type
       schema:
         type: string
-        enum: [user_lock] # future: lock_id,optimistic_locking
+        enum: [user_lock, id_lock]
       description: |
-        Angir låsetype som skal brukes (foreløpig er kun `user_lock` støttet). Krever at brukeren har skrivetilgang mot dataset'et.
+        Angir låsetype som skal brukes. Krever at brukeren har skrivetilgang mot dataset'et.
         
         *user_lock*
 
         Hver bruker har én lås per dataset. Hver gang data hentes ut med `user_lock` legges objektene til denne låsen. 
-        Alle objekter i låsen låses opp neste gang brukeren skriver data til dataset'et.
 
         Låsen vil fjernes neste gang brukeren skriver data til dataset'et med `user_lock`, eller dersom låsen slettes.
+
+        *id_lock*
+
+        Hver bruker kan lage flere låser per dataset. Låsing av objektene må håndteres med POST /datasets/:id/locks.
+        
+        Låsen vil fjernes neste gang brukeren skriver data til dataset'et med `id_lock` og angitt låsenøkkel med `locking_id`, eller dersom låsen slettes.
+        
     lokalIdParam:
       in: path
       name: lokalId

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -248,9 +248,9 @@ paths:
     get:
       tags:
        - metadata
-      summary: Hent arkiv loggen for et bestemt dataset
+      summary: Hent endringsloggen for et bestemt dataset
       description: |
-        Hent en liste med oppføringer i arkiv loggen
+        Henter en liste med oppføringer i endringsloggen for et bestemt dataset
       operationId: getLog
       parameters:        
         - $ref: '#/components/parameters/clientHeaderParam'
@@ -355,6 +355,11 @@ paths:
               summary: Bygning og bygningsnummer lik 1234
               description: |
                Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer = 1234.
+            bygningsnummergt:
+              value: 'gt(Bygning/bygningsnummer,1234)'
+              summary: Bygning og bygningsnummer større enn 1234
+              description: |
+               Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer > 1234.
             lokalid:
               value: 'eq(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6)'
               summary: Spørring etter ett bestemt objekt med gitt lokalid

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -884,14 +884,15 @@ paths:
     get:
       tags:
        - locks
-      summary: Hent informasjon om brukerens låste features i et bestemt dataset. Bruk `application/vnd.kartverket.ngis.locks+json` for kun å se egne låser, og `application/vnd.kartverket.ngis.all_locks+json` for også å se andres låser.
+      summary: Hent informasjon om låste features i et bestemt dataset. 
       description: |
-        Henter bl.a. informasjon om hvilke objekter brukeren har låst i et bestemt dataset.
+        Bruk `application/vnd.kartverket.ngis.locks+json` i `Accept`-headeren for kun å se egne låser, og `application/vnd.kartverket.ngis.all_locks+json` i `Accept`-headeren for også å se andres låser.
       operationId: getDatasetLocks
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lockingParam'
+        - $ref: '#/components/parameters/lockingIdParam'
         - $ref: '#/components/parameters/bboxParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
@@ -916,9 +917,9 @@ paths:
     delete:
       tags:
         - locks
-      summary: Fjerne alle låser brukeren har i et bestemt dataset
+      summary: Fjerne brukerlåsen i et bestemt dataset
       description: |
-        Fjerne alle låser brukeren har i et bestemt dataset
+        Merk at det KUN er brukerlåsen (locking_type=user_lock) som fjernesFjerne alle låser brukeren har i et bestemt dataset
       operationId: deleteDatasetLocks        
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
@@ -1300,7 +1301,8 @@ components:
         format: int32
         minimum: 1
       description: |
-        Brukes ved skriving av data med lås, dersom lås er hentet med `locking_type=id_lock`.      
+        Angir låsenøkkel dersom `locking_type=id_lock` er brukt.   
+      example: 123
     lokalIdParam:
       in: path
       name: lokalId

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -265,6 +265,19 @@ paths:
             application/vnd.kartverket.ngis.dataset_changelog+json; version=1.0:  # Media type
               schema: 
                 $ref: '#/components/schemas/Log'    # Reference to object definition
+              examples:
+                Bbox:
+                  summary: |
+                    Eksempel på uthentet endringslogg med bbox
+                  externalValue: "https://raw.githubusercontent.com/kartverket/SFKB-API/master/spec/examples/changelog/Bbox.json"
+                Transformation:
+                  summary: |
+                    Eksempel på uthentet endringslogg med transformasjon
+                  externalValue: "https://raw.githubusercontent.com/kartverket/SFKB-API/master/spec/examples/changelog/Transformasjon.json"
+                TransformationBboxNormalization:
+                  summary: |
+                    Eksempel på uthentet endringslogg med transformasjon, bbox og normalisering
+                  externalValue: "https://raw.githubusercontent.com/kartverket/SFKB-API/master/spec/examples/changelog/BboxTransformasjonNomralisering.json"
         '401':
           description: Gyldig autentisering av brukeren mangler eller er ugyldig
         '406':

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -339,47 +339,7 @@ paths:
         - $ref: '#/components/parameters/referencesParam'
         - $ref: '#/components/parameters/limitParam'
         - $ref: '#/components/parameters/cursorParam'
-        - in: query
-          name: query
-          schema:
-            type: string
-          description: |
-            ### Filter på egenskaper og/eller objekttype for å begrense hvilke features som hentes ut.
-            
-            Spørrespråket er basert på [RQL](https://github.com/persvr/rql).
-            
-            Man kan bruke `eq`, `lt` (less than), `le` (less than or equal), `gt` (greater than), `ge` (greater than or equal) eller `in` (lik eq, men med liste av verdier - kun støttet for spørring etter identifikasjon/lokalid).
-          examples:
-            bygningsnummer:
-              value: 'eq(Bygning/bygningsnummer,1234)'
-              summary: Bygning og bygningsnummer lik 1234
-              description: |
-               Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer = 1234.
-            bygningsnummergt:
-              value: 'gt(Bygning/bygningsnummer,1234)'
-              summary: Bygning og bygningsnummer større enn 1234
-              description: |
-               Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer > 1234.
-            lokalid:
-              value: 'eq(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6)'
-              summary: Spørring etter ett bestemt objekt med gitt lokalid
-              description: |
-                Når et objekt hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
-            lokalid_multi:
-              value: 'in(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6,023a7b9b-7088-482f-a3cf-9761b9700000)'
-              summary: Spørring etter flere objekter med lokalid
-              description: |
-                Når objekt(er) hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
-            feature_type:
-              value: 'eq(*,Bygning)'
-              summary: Spørring etter alle objekter med en bestemt objekttype, uten noen bestemt egenskapsverdi.
-              description: |
-                Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
-            feature_type_multi:
-              value: 'in(*,Bygning,AnnenBygning)'
-              summary: Spørring etter alle objekter med flere objekttyper, uten noen bestemt egenskapsverdi.
-              description: |
-                Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
+        - $ref: '#/components/parameters/queryParam'
         - in: query
           name: dataset_at
           schema:
@@ -899,6 +859,10 @@ paths:
         - $ref: '#/components/parameters/bboxParam'
         - $ref: '#/components/parameters/crsEPSGParam'
         - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
+        - $ref: '#/components/parameters/referencesParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/queryParam'
+        
       responses:
         '200':      # Response
           description: OK
@@ -1317,6 +1281,48 @@ components:
         format: uuid
       required: true
       description: Identifikasjon.Lokalid til objektet
+    queryParam:
+      in: query
+      name: query
+      schema:
+        type: string
+      description: |
+        ### Filter på egenskaper og/eller objekttype for å begrense hvilke features som hentes ut.
+        
+        Spørrespråket er basert på [RQL](https://github.com/persvr/rql).
+        
+        Man kan bruke `eq`, `lt` (less than), `le` (less than or equal), `gt` (greater than), `ge` (greater than or equal) eller `in` (lik eq, men med liste av verdier - kun støttet for spørring etter identifikasjon/lokalid).
+      examples:
+        bygningsnummer:
+          value: 'eq(Bygning/bygningsnummer,1234)'
+          summary: Bygning og bygningsnummer lik 1234
+          description: |
+           Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer = 1234.
+        bygningsnummergt:
+          value: 'gt(Bygning/bygningsnummer,1234)'
+          summary: Bygning og bygningsnummer større enn 1234
+          description: |
+           Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer > 1234.
+        lokalid:
+          value: 'eq(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6)'
+          summary: Spørring etter ett bestemt objekt med gitt lokalid
+          description: |
+            Når et objekt hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
+        lokalid_multi:
+          value: 'in(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6,023a7b9b-7088-482f-a3cf-9761b9700000)'
+          summary: Spørring etter flere objekter med lokalid
+          description: |
+            Når objekt(er) hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
+        feature_type:
+          value: 'eq(*,Bygning)'
+          summary: Spørring etter alle objekter med en bestemt objekttype, uten noen bestemt egenskapsverdi.
+          description: |
+            Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
+        feature_type_multi:
+          value: 'in(*,Bygning,AnnenBygning)'
+          summary: Spørring etter alle objekter med flere objekttyper, uten noen bestemt egenskapsverdi.
+          description: |
+            Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
     limitParam:
       in: query
       name: limit

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -932,17 +932,26 @@ paths:
           description: Ugyldig brukernavn og/eller passord
         '404':
           description: Fant ikke angitt dataset
-  /datasets/{datasetId}/locks/{lockId}:    
+  /datasets/{datasetId}/locks/{lockId}: 
     delete:
       tags:
         - locks
       summary: Fjerne en enkelt lås
       description: |
         Fjerne låsen angitt med id.
-      operationId: deleteDatasetLocks        
+      operationId: deleteDatasetLock      
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
+        - in: path
+          name: lockId
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+          required: true
+          example: 123
+          description: Låsenøkkel fås fra GET /datasets/{datasetId}/locks eller `Unlock-Key`-headeren ved henting av data med `locking_type`-parameter
       responses:
         '204': # Success
           description: No Content

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -934,7 +934,7 @@ paths:
         - locks
       summary: Fjerne brukerlåsen i et bestemt dataset
       description: |
-        Merk at det KUN er brukerlåsen (locking_type=user_lock) som fjernesFjerne alle låser brukeren har i et bestemt dataset
+        Merk at det KUN er brukerlåsen (locking_type=user_lock) som fjernes
       operationId: deleteDatasetLocks        
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -311,15 +311,18 @@ paths:
             
             Spørrespråket er basert på [RQL](https://github.com/persvr/rql).
             
-            Foreløpig støttes kun `eq` og `in` for bestemte objekttyper og egenskaper.
-            
-            Eksemplene inneholder alle støttede spørringer.
+            Man kan bruke `eq`, `lt` (less than), `le` (less than or equal), `gt` (greater than), `ge` (greater than or equal) eller `in` (lik eq, men med liste av verdier - kun støttet for spørring etter identifikasjon/lokalid).
           examples:
             bygningsnummer:
               value: 'eq(Bygning/bygningsnummer,1234)'
-              summary: Spørring etter ett bestemt bygningsnummer for objekttypen Bygning
+              summary: Bygning og bygningsnummer lik 1234
               description: |
                Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer = 1234.
+            bygningsnummer:
+              value: 'gt(Bygning/bygningsnummer,1234)'
+              summary: Bygning og bygningsnummer større enn 1234
+              description: |
+               Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer > 1234.
             lokalid:
               value: 'eq(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6)'
               summary: Spørring etter ett bestemt objekt med gitt lokalid
@@ -332,14 +335,14 @@ paths:
                 Når objekt(er) hentes ut med lokalid er det normalt ikke nødvendig å filtrere på objekttype, derfor er objekttypen angitt med `*`.
             feature_type:
               value: 'eq(*,Bygning)'
-              summary: Spørring etter alle objekter med en bestemt objekttype
+              summary: Spørring etter alle objekter med en bestemt objekttype, uten noen bestemt egenskapsverdi.
               description: |
-                Vi bruker `*` for å angi at vi kun filtrerer på objekttype.
+                Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
             feature_type_multi:
               value: 'in(*,Bygning,AnnenBygning)'
-              summary: Spørring etter flere objekter med lokalid
+              summary: Spørring etter alle objekter med flere objekttyper, uten noen bestemt egenskapsverdi.
               description: |
-                Vi bruker `*` for å angi at vi kun filtrerer på objekttype.
+                Vi bruker `*` uten noen angitt egenskap for å angi at vi kun filtrerer på objekttype.
         - in: query
           name: dataset_at
           schema:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -244,6 +244,37 @@ paths:
           description: Intern feil på serveren (kallet er ikke implementert)
         '503':
           description: Intern feil på serveren (tjenesten er utilgjengelig)
+  /datasets/{datasetId}/log:
+    get:
+      tags:
+       - metadata
+      summary: Hent arkiv loggen for et bestemt dataset
+      description: |
+        Hent en liste med oppføringer i arkiv loggen
+      operationId: getLog
+      parameters:        
+        - $ref: '#/components/parameters/clientHeaderParam'
+        - $ref: '#/components/parameters/datasetIdParam'
+        - $ref: '#/components/parameters/bboxParam'
+        - $ref: '#/components/parameters/crsEPSGParam'
+        - $ref: '#/components/parameters/crsNormalizedForVisualizationParam'
+      responses:
+        '200':      # Response
+          description: OK
+          content:  # Response body
+            application/vnd.kartverket.ngis.dataset_changelog+json; version=1.0:  # Media type
+              schema: 
+                $ref: '#/components/schemas/Log'    # Reference to object definition
+        '401':
+          description: Gyldig autentisering av brukeren mangler eller er ugyldig
+        '406':
+          description: Formatet klienten ønsker på data er ugyldig. Klienten har f.eks en ugyldig Accept-header og kan ikke motta data på et format som serveren kan levere
+        '500':
+          description: Intern feil på serveren
+        '501':
+          description: Intern feil på serveren (kallet er ikke implementert)
+        '503':
+          description: Intern feil på serveren (tjenesten er utilgjengelig)
   /datasets/{datasetId}/job_status/{jobId}:
     get:
       tags:
@@ -993,6 +1024,88 @@ components:
           $ref: '#/components/schemas/BoundingBox'
         copy_transaction_token:
           type: string
+    Log:
+      type: array
+      items:
+        type: object
+        properties:
+            areaname:
+              type: string
+            comment:
+              type: string
+              example:
+                "antall porsjoner 6"
+            features:
+              type: object
+              properties:
+                  bbox:
+                    type: array
+                    items:
+                      type: number
+                    example:
+                      - 582455.36
+                      - 6770367.69
+                      - 582957.75
+                      - 6770780.09
+                  created:
+                    type: string
+                    example:
+                      "0"
+                  erased:
+                    type: string
+                    example:
+                      "0"
+                  replaced:
+                    type: string
+                    example:
+                      "2"
+            operations:
+              type: object
+              properties:
+                ArchiveMetadata:
+                  type: boolean
+                  example:
+                    false
+                DataWrittenWithHistory:
+                  type: boolean
+                  example:
+                    false
+                DelArchive:
+                  type: boolean
+                DelHistory:
+                  type: boolean
+                DelHistoryBeforeTimestamp:
+                  type: boolean
+                DelHorizontalRefSys:
+                  type: boolean
+                DelSpatialData:
+                  type: boolean
+                DelTypeRegistry:
+                  type: boolean
+                DelVerticalRefSys:
+                  type: boolean
+                HistoryWasRemoved:
+                  type: boolean
+                LastTransactionId:
+                  type: boolean
+                Parameters:
+                  type: boolean
+                SinglePortionWithCommit:
+                  type: boolean
+                TypeRegistry:
+                  type: boolean
+            taskname:
+              type: string
+              example:
+                "havn_22_nk"
+            timestamp:
+              type: string
+              example:
+                "2023-02-13T14:59:08"
+            username:
+              type: string
+              example:
+                "test_bruker_nk"
     Locks:
       type: array
       items:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -551,6 +551,7 @@ paths:
       operationId: updateDatasetFeatures
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
+        - $ref: '#/components/parameters/commentHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lockingParam'
         - $ref: '#/components/parameters/lockingIdParam'
@@ -819,6 +820,7 @@ paths:
       operationId: updateDatasetFeatureAttributes
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
+        - $ref: '#/components/parameters/commentHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
         - $ref: '#/components/parameters/lokalIdParam'
       requestBody:
@@ -1175,6 +1177,14 @@ components:
       required: true
       description: Brukes for å kunne identifisere klienten som er brukt
       example: 'ExampleApp 10.0.0 (Build 54321)'
+    commentHeaderParam:
+      in: header
+      name: X-Metadata-Comment
+      schema:
+        type: string
+      required: true
+      description: Brukes for legge inn kommentar i arkiv loggen
+      example: 'Innsjekk gjort av Norkart'
     datasetIdParam:
       in: path
       name: datasetId

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -324,11 +324,6 @@ paths:
               summary: Bygning og bygningsnummer lik 1234
               description: |
                Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer = 1234.
-            bygningsnummer:
-              value: 'gt(Bygning/bygningsnummer,1234)'
-              summary: Bygning og bygningsnummer større enn 1234
-              description: |
-               Spørringen henter ut alle objekter med objekttypen Bygning med egenskapen bygningsnummer > 1234.
             lokalid:
               value: 'eq(*/identifikasjon/lokalid,000a7b9b-7088-482f-a3cf-9761b97a54b6)'
               summary: Spørring etter ett bestemt objekt med gitt lokalid

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -923,7 +923,26 @@ paths:
       parameters:
         - $ref: '#/components/parameters/clientHeaderParam'
         - $ref: '#/components/parameters/datasetIdParam'
-        - $ref: '#/components/parameters/lockingParam'
+      responses:
+        '204': # Success
+          description: No Content
+        '401':
+          description: Gyldig autentisering av brukeren mangler eller er ugyldig
+        '403':
+          description: Ugyldig brukernavn og/eller passord
+        '404':
+          description: Fant ikke angitt dataset
+  /datasets/{datasetId}/locks/{lockId}:    
+    delete:
+      tags:
+        - locks
+      summary: Fjerne en enkelt lås
+      description: |
+        Fjerne låsen angitt med id.
+      operationId: deleteDatasetLocks        
+      parameters:
+        - $ref: '#/components/parameters/clientHeaderParam'
+        - $ref: '#/components/parameters/datasetIdParam'
       responses:
         '204': # Success
           description: No Content


### PR DESCRIPTION
Vi har sett på mangler i NGIS-OpenAPI sammenliknet med dagens NGIS-API. Denne PR inneholder dokumentasjon av pågående arbeid. Endringer kan skje i forbindelse med standardisering, derfor holdes denne PR i draft-form foreløpig.

- [x] Egenskapsspørringer: støtte sammenlikninger ut over eq: større enn, større enn eller lik, mindre enn, mindre enn eller lik
- [x] Låsing med dagens NGIS-API-låser som oppfører seg litt annerledes enn brukerlåser/user_lock: ved forsøk på låsing av et område vil alle objekter som ikke er låst fra før, låses. Andre objekter forblir låst av andre, kallet feiler ikke.
- [x] Hent endringslogg for aktuelt dataset (med mulighet for å angi et (mindre) område innenfor dataset'et.
- [x] Kunne angi kommentar til endringsloggen ved skriving av data til apiet.
- [x] Kunne angi polygonavgrensning med `polygon`-parameteret 

Se redocly-dokumentasjon her http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/kartverket/NGIS-OpenAPI/meastp-patch-24/spec/openapi.yaml&nocors

Se swagger editor her https://editor.swagger.io/?url=https://raw.githubusercontent.com/kartverket/NGIS-OpenAPI/meastp-patch-24/spec/openapi.yaml